### PR TITLE
signing not singing

### DIFF
--- a/OpenKeychain/src/main/res/raw/help_faq.md
+++ b/OpenKeychain/src/main/res/raw/help_faq.md
@@ -99,7 +99,7 @@ It is not required cryptographically, but prevents simple stealing of your keys.
 Anyone who can physically access your device can simply delete the app data from Android OS.
 Also, asking for a password before delete would prevent you from deleting keys where you forgot your password
 
-## I have more than one subkey capable of singing. Which one is selected when signing with this OpenPGP key?
+## I have more than one subkey capable of signing. Which one is selected when signing with this OpenPGP key?
 
 OpenKeychain assumes that OpenPGP keys hold one usable signing subkey only and selects the first non-revoked non-expired non-stripped one it finds in the unordered list of subkeys.
 We consider having more than one valid signing subkey an advanced usecase. You can either strip subkeys that should not be used using OpenKeychain's edit key screen or explicitly select the right subkeys when exporting from gpg with ``gpg --export-secret-subkeys``.


### PR DESCRIPTION
Replaced singing with signing

I have replaced the incorrect word 'singing' to 'signing'

## Description
Previously singing was present in the text.  I corrected this to signing.

## Motivation and Context
Correct spelling helps make the program look more professional.  I use this on a regular
basis and I want to help make it better.

## How Has This Been Tested?
Plain-text change that doesn't require recompilation to test.

## Screenshots (if appropriate):

## Types of changes
Text change (non-code) change.
